### PR TITLE
Stabilize checkout and generator step flow

### DIFF
--- a/src/components/StoryGenerator.tsx
+++ b/src/components/StoryGenerator.tsx
@@ -22,10 +22,10 @@ export const StoryGenerator: React.FC = () => {
         setStep('preview');
         break;
       case 'preview':
-        setStep('export');
+        setStep('edit');
         break;
-      case 'export':
-        setStep('print');
+      case 'edit':
+        setStep('export');
         break;
     }
   };
@@ -35,11 +35,11 @@ export const StoryGenerator: React.FC = () => {
       case 'preview':
         setStep('setup');
         break;
-      case 'export':
+      case 'edit':
         setStep('preview');
         break;
-      case 'print':
-        setStep('export');
+      case 'export':
+        setStep('edit');
         break;
     }
   };
@@ -83,8 +83,8 @@ export const StoryGenerator: React.FC = () => {
             
             {/* Step indicator */}
             <div className="flex items-center gap-1 sm:gap-2">
-              {['Setup', 'Preview', 'Export'].map((step, index) => {
-                const stepNames = ['setup', 'preview', 'export'];
+              {['Setup', 'Preview', 'Edit', 'Export'].map((step, index) => {
+                const stepNames = ['setup', 'preview', 'edit', 'export'];
                 const isActive = stepNames[index] === currentStep;
                 const isComplete = stepNames.indexOf(currentStep) > index;
                 
@@ -131,11 +131,19 @@ export const StoryGenerator: React.FC = () => {
           />
         )}
         
-        {currentStep === 'export' && (
+        {currentStep === 'edit' && (
           <PageEditor
             config={config}
             onConfigChange={updateConfig}
             onNext={handleNext}
+            onBack={handleBack}
+          />
+        )}
+
+        {currentStep === 'export' && (
+          <ExportPanel
+            config={config}
+            onConfigChange={updateConfig}
             onBack={handleBack}
           />
         )}

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,7 @@ export interface StoryPage {
 }
 
 // UI State Types
-export type AppStep = 'setup' | 'preview' | 'export' | 'print';
+export type AppStep = 'setup' | 'preview' | 'edit' | 'export';
 
 export interface AppState {
   currentStep: AppStep;


### PR DESCRIPTION
## Summary
- align the story generator step progression with dedicated edit and export phases to keep navigation consistent
- harden the Stripe checkout path by requiring a configured publishable key and surfacing a clear fallback message when it is missing
- add stronger typing around billing intent/confirmation responses to prevent runtime error handling gaps

## Testing
- `npx eslint src/components/CheckoutSheet.tsx`
- `npx eslint src/components/StoryGenerator.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c3234a49708332b148ff7a7554f54e