### PR TITLE
Stabilize print checkout responses

### DIFF
--- a/src/components/CheckoutSheet.tsx
+++ b/src/components/CheckoutSheet.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { loadStripe } from '@stripe/stripe-js';
+import { loadStripe, Stripe } from '@stripe/stripe-js';
 import {
   Elements,
   CardElement,
@@ -15,15 +15,39 @@ import { supabase } from '@/integrations/supabase/client';
 import { getSession } from '@/lib/session';
 import { PRICES } from '@/lib/pricing';
 
-const stripePromise = loadStripe(
-  import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY || 
-  'pk_test_51QdAAA2O5vKBkgBMAAAAA' // Placeholder test key
-);
+const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY;
+
+let stripePromise: Promise<Stripe | null> | null = null;
+
+if (publishableKey) {
+  stripePromise = loadStripe(publishableKey);
+} else {
+  if (import.meta.env.DEV) {
+    // Surface a clear warning during development so missing configuration
+    // doesn't silently break checkout flows.
+    console.warn(
+      '[CheckoutSheet] Missing VITE_STRIPE_PUBLISHABLE_KEY. Stripe checkout will be disabled.'
+    );
+  }
+}
 
 interface CheckoutSheetProps {
   item: 'export' | 'print' | 'subscription';
   onSuccess: (billingToken: string) => void;
   onCancel: () => void;
+}
+
+interface BillingIntentResponse {
+  clientSecret: string | null;
+  amount: number;
+  currency: string;
+  testBypass?: boolean;
+  free?: boolean;
+  paymentIntentId?: string | null;
+}
+
+interface BillingConfirmResponse {
+  billingToken: string;
 }
 
 const CheckoutForm = ({ item, onSuccess, onCancel }: CheckoutSheetProps) => {
@@ -32,7 +56,7 @@ const CheckoutForm = ({ item, onSuccess, onCancel }: CheckoutSheetProps) => {
   const [loading, setLoading] = useState(false);
   const [discountCode, setDiscountCode] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [paymentIntent, setPaymentIntent] = useState<any>(null);
+  const [paymentIntent, setPaymentIntent] = useState<BillingIntentResponse | null>(null);
 
   const session = getSession();
   const isFirstExport = item === 'export' && !session.firstExportUsed;
@@ -59,7 +83,7 @@ const CheckoutForm = ({ item, onSuccess, onCancel }: CheckoutSheetProps) => {
     setError(null);
 
     try {
-      const { data, error } = await supabase.functions.invoke('billing-intent', {
+      const { data, error } = await supabase.functions.invoke<BillingIntentResponse>('billing-intent', {
         body: { item, discountCode: discountCode || undefined, sessionData: session }
       });
 
@@ -67,19 +91,20 @@ const CheckoutForm = ({ item, onSuccess, onCancel }: CheckoutSheetProps) => {
 
       if (data.testBypass || data.free) {
         // Skip payment, confirm directly
-        const confirmResult = await supabase.functions.invoke('billing-confirm', {
+        const confirmResult = await supabase.functions.invoke<BillingConfirmResponse>('billing-confirm', {
           body: { item, discountCode, sessionData: session }
         });
 
         if (confirmResult.error) throw confirmResult.error;
-        
+
         onSuccess(confirmResult.data.billingToken);
         return;
       }
 
       setPaymentIntent(data);
-    } catch (err: any) {
-      setError(err.message || 'Failed to create payment intent');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to create payment intent';
+      setError(message);
     } finally {
       setLoading(false);
     }
@@ -87,6 +112,11 @@ const CheckoutForm = ({ item, onSuccess, onCancel }: CheckoutSheetProps) => {
 
   const handlePayment = async () => {
     if (!stripe || !elements || !paymentIntent) return;
+    if (!paymentIntent.clientSecret) {
+      setError('Missing payment intent details. Please start checkout again.');
+      setPaymentIntent(null);
+      return;
+    }
 
     setLoading(true);
     setError(null);
@@ -110,20 +140,21 @@ const CheckoutForm = ({ item, onSuccess, onCancel }: CheckoutSheetProps) => {
 
       if (confirmedPayment.status === 'succeeded') {
         // Confirm with backend
-        const confirmResult = await supabase.functions.invoke('billing-confirm', {
-          body: { 
-            item, 
+        const confirmResult = await supabase.functions.invoke<BillingConfirmResponse>('billing-confirm', {
+          body: {
+            item,
             paymentRef: confirmedPayment.id,
-            sessionData: session 
+            sessionData: session
           }
         });
 
         if (confirmResult.error) throw confirmResult.error;
-        
+
         onSuccess(confirmResult.data.billingToken);
       }
-    } catch (err: any) {
-      setError(err.message || 'Payment failed');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Payment failed';
+      setError(message);
     } finally {
       setLoading(false);
     }
@@ -176,17 +207,27 @@ const CheckoutForm = ({ item, onSuccess, onCancel }: CheckoutSheetProps) => {
         )}
 
         {!paymentIntent ? (
-          <Button 
-            onClick={handleCreateIntent} 
-            disabled={loading}
-            className="w-full"
-          >
-            {loading ? 'Processing...' : (isFirstExport ? 'Continue (Free)' : 'Proceed to Payment')}
-          </Button>
+          <div className="space-y-2">
+            <Button
+              onClick={handleCreateIntent}
+              disabled={loading}
+              className="w-full"
+            >
+              {loading ? 'Processing...' : (isFirstExport ? 'Continue (Free)' : 'Proceed to Payment')}
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={onCancel}
+              className="w-full"
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+          </div>
         ) : (
           <div className="space-y-4">
             <div className="p-3 border rounded">
-              <CardElement 
+              <CardElement
                 options={{
                   style: {
                     base: {
@@ -202,8 +243,8 @@ const CheckoutForm = ({ item, onSuccess, onCancel }: CheckoutSheetProps) => {
             </div>
             
             <div className="flex gap-2">
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 onClick={onCancel}
                 disabled={loading}
                 className="flex-1"
@@ -221,19 +262,34 @@ const CheckoutForm = ({ item, onSuccess, onCancel }: CheckoutSheetProps) => {
           </div>
         )}
 
-        <Button 
-          variant="ghost" 
-          onClick={onCancel}
-          className="w-full"
-        >
-          Cancel
-        </Button>
       </CardContent>
     </Card>
   );
 };
 
+const MissingStripeConfiguration: React.FC<{ onCancel: () => void }> = ({ onCancel }) => (
+  <Card className="w-full max-w-md">
+    <CardHeader>
+      <CardTitle>Payment Temporarily Unavailable</CardTitle>
+    </CardHeader>
+    <CardContent className="space-y-4 text-sm text-muted-foreground">
+      <p>
+        We couldn&apos;t initialise Stripe because the publishable key is not configured.
+        Please set the <code>VITE_STRIPE_PUBLISHABLE_KEY</code> environment variable and
+        reload the page.
+      </p>
+      <Button className="w-full" onClick={onCancel}>
+        Close
+      </Button>
+    </CardContent>
+  </Card>
+);
+
 export const CheckoutSheet = (props: CheckoutSheetProps) => {
+  if (!stripePromise) {
+    return <MissingStripeConfiguration onCancel={props.onCancel} />;
+  }
+
   return (
     <Elements stripe={stripePromise}>
       <CheckoutForm {...props} />

--- a/src/components/StoryGenerator.tsx
+++ b/src/components/StoryGenerator.tsx
@@ -22,10 +22,10 @@ export const StoryGenerator: React.FC = () => {
         setStep('preview');
         break;
       case 'preview':
-        setStep('export');
+        setStep('edit');
         break;
-      case 'export':
-        setStep('print');
+      case 'edit':
+        setStep('export');
         break;
     }
   };
@@ -35,11 +35,11 @@ export const StoryGenerator: React.FC = () => {
       case 'preview':
         setStep('setup');
         break;
-      case 'export':
+      case 'edit':
         setStep('preview');
         break;
-      case 'print':
-        setStep('export');
+      case 'export':
+        setStep('edit');
         break;
     }
   };
@@ -73,7 +73,7 @@ export const StoryGenerator: React.FC = () => {
       {/* Header */}
       <header className="border-b bg-background/80 backdrop-blur-sm sticky top-0 z-50">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 sm:py-4">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-wrap items-center justify-between gap-3 sm:gap-4">
             <div className="flex items-center gap-2 sm:gap-3">
               <div className="w-7 h-7 sm:w-8 sm:h-8 rounded-lg bg-gradient-warm flex items-center justify-center">
                 <span className="text-white font-bold text-base sm:text-lg">S</span>
@@ -82,9 +82,9 @@ export const StoryGenerator: React.FC = () => {
             </div>
             
             {/* Step indicator */}
-            <div className="flex items-center gap-1 sm:gap-2">
-              {['Setup', 'Preview', 'Export'].map((step, index) => {
-                const stepNames = ['setup', 'preview', 'export'];
+            <div className="flex flex-wrap items-center gap-1 sm:gap-2 w-full sm:w-auto">
+              {['Setup', 'Preview', 'Edit', 'Export'].map((step, index) => {
+                const stepNames = ['setup', 'preview', 'edit', 'export'];
                 const isActive = stepNames[index] === currentStep;
                 const isComplete = stepNames.indexOf(currentStep) > index;
                 
@@ -131,11 +131,19 @@ export const StoryGenerator: React.FC = () => {
           />
         )}
         
-        {currentStep === 'export' && (
+        {currentStep === 'edit' && (
           <PageEditor
             config={config}
             onConfigChange={updateConfig}
             onNext={handleNext}
+            onBack={handleBack}
+          />
+        )}
+
+        {currentStep === 'export' && (
+          <ExportPanel
+            config={config}
+            onConfigChange={updateConfig}
             onBack={handleBack}
           />
         )}

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,7 @@ export interface StoryPage {
 }
 
 // UI State Types
-export type AppStep = 'setup' | 'preview' | 'export' | 'print';
+export type AppStep = 'setup' | 'preview' | 'edit' | 'export';
 
 export interface AppState {
   currentStep: AppStep;
@@ -135,5 +135,7 @@ export interface PrintOrderResponse {
   provider: string;
   orderId?: string;
   checkoutUrl?: string;
-  raw?: any;
+  message?: string;
+  error?: string;
+  raw?: unknown;
 }


### PR DESCRIPTION
## Summary
- guard the Stripe checkout workflow against missing client secrets and let users cancel before payment
- surface structured print order results and errors in the export panel with a shared response type
- normalize the create-print-order edge function to return typed success/error payloads for downstream consumers

## Testing
- `npx eslint src/components/CheckoutSheet.tsx src/components/ExportPanel.tsx src/api.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c3234a49708332b148ff7a7554f54e