### PR TITLE
Implement auth, AI pipeline, and export improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { StoryGenerator } from "./components/StoryGenerator";
+import { AuthProvider } from "./context/AuthContext";
+import { AuthGate } from "./components/AuthGate";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -13,13 +15,22 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<StoryGenerator />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
+      <AuthProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route
+              path="/"
+              element={(
+                <AuthGate>
+                  <StoryGenerator />
+                </AuthGate>
+              )}
+            />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </AuthProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/components/AuthGate.tsx
+++ b/src/components/AuthGate.tsx
@@ -1,0 +1,137 @@
+import { FormEvent, ReactNode, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Loader2, LogIn, UserPlus } from 'lucide-react';
+import { useAuth } from '@/context/AuthContext';
+
+interface AuthGateProps {
+  children: ReactNode;
+}
+
+export const AuthGate: React.FC<AuthGateProps> = ({ children }) => {
+  const { user, loading, mode, setMode, error, clearError, signIn, signUp } = useAuth();
+  const [formLoading, setFormLoading] = useState(false);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!email || !password) {
+      return;
+    }
+
+    setFormLoading(true);
+    clearError();
+
+    try {
+      if (mode === 'sign-in') {
+        await signIn(email, password);
+      } else {
+        await signUp(email, password);
+      }
+    } catch (err) {
+      console.error('[AuthGate] Authentication failed', err);
+    } finally {
+      setFormLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-soft">
+        <Loader2 className="w-8 h-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (user) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-soft px-4">
+      <Card className="w-full max-w-md shadow-xl">
+        <CardHeader className="text-center space-y-2">
+          <CardTitle className="text-2xl font-display">
+            {mode === 'sign-in' ? 'Sign in to continue' : 'Create your account'}
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Your stories are saved securely to your account. Use the same email next time to pick up where you left off.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="auth-email">Email</label>
+              <Input
+                id="auth-email"
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                placeholder="you@example.com"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="auth-password">Password</label>
+              <Input
+                id="auth-password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                placeholder="••••••••"
+                minLength={8}
+                required
+              />
+            </div>
+
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <Button type="submit" className="w-full" disabled={formLoading}>
+              {formLoading ? (
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              ) : mode === 'sign-in' ? (
+                <LogIn className="w-4 h-4 mr-2" />
+              ) : (
+                <UserPlus className="w-4 h-4 mr-2" />
+              )}
+              {mode === 'sign-in' ? 'Sign In' : 'Create Account'}
+            </Button>
+          </form>
+
+          <div className="mt-4 text-center text-sm text-muted-foreground">
+            {mode === 'sign-in' ? (
+              <button
+                className="text-primary font-medium"
+                onClick={() => {
+                  setMode('sign-up');
+                  clearError();
+                }}
+                type="button"
+              >
+                Need an account? Create one
+              </button>
+            ) : (
+              <button
+                className="text-primary font-medium"
+                onClick={() => {
+                  setMode('sign-in');
+                  clearError();
+                }}
+                type="button"
+              >
+                Have an account? Sign in
+              </button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/components/CheckoutSheet.tsx
+++ b/src/components/CheckoutSheet.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { supabase } from '@/integrations/supabase/client';
 import { getSession } from '@/lib/session';
+import { useAuth } from '@/context/AuthContext';
 import { PRICES } from '@/lib/pricing';
 
 const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY;
@@ -57,7 +58,8 @@ const CheckoutForm = ({ item, onSuccess, onCancel }: CheckoutSheetProps) => {
   const [error, setError] = useState<string | null>(null);
   const [paymentIntent, setPaymentIntent] = useState<BillingIntentResponse | null>(null);
 
-  const session = getSession();
+  const { user } = useAuth();
+  const session = getSession(user?.id);
   const isFirstExport = item === 'export' && !session.firstExportUsed;
   
   const getItemPrice = () => {

--- a/src/components/PreviewGenerate.tsx
+++ b/src/components/PreviewGenerate.tsx
@@ -30,6 +30,7 @@ export const PreviewGenerate: React.FC<PreviewGenerateProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [startTime, setStartTime] = useState<number>(0);
   const [estimatedTimeRemaining, setEstimatedTimeRemaining] = useState<string>('');
+  const [isGenerating, setIsGenerating] = useState(false);
 
   const updateProgress = (newProgress: number) => {
     setProgress(newProgress);
@@ -67,6 +68,7 @@ export const PreviewGenerate: React.FC<PreviewGenerateProps> = ({
       setError(null);
       setStartTime(Date.now());
       setCurrentStep('planning');
+      setIsGenerating(true);
       updateProgress(5);
 
       // Step 1: Plan the story
@@ -140,6 +142,7 @@ export const PreviewGenerate: React.FC<PreviewGenerateProps> = ({
       setProgress(0);
       setEstimatedTimeRemaining('');
     }
+    setIsGenerating(false);
   };
 
   const getStepStatus = (step: GenerationStep) => {
@@ -446,6 +449,7 @@ export const PreviewGenerate: React.FC<PreviewGenerateProps> = ({
               onClick={generateStory}
               size="lg"
               className="px-8 py-3 text-lg font-medium animate-gentle-bounce"
+              disabled={isGenerating}
             >
               <Sparkles className="w-5 h-5 mr-2" />
               Generate Story

--- a/src/components/StoryGenerator.tsx
+++ b/src/components/StoryGenerator.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
+import { LogOut } from 'lucide-react';
 import { useAppState } from '../state';
+import { useAuth } from '@/context/AuthContext';
+import { Button } from '@/components/ui/button';
 import { SetupForm } from './SetupForm';
 import { PreviewGenerate } from './PreviewGenerate';
 import { PageEditor } from './PageEditor';
@@ -12,7 +15,9 @@ export const StoryGenerator: React.FC = () => {
     updateConfig,
     setStep,
     canProceedToNext,
+    resetState,
   } = useAppState();
+  const { user, signOut } = useAuth();
 
   const { currentStep, config } = state;
 
@@ -80,7 +85,25 @@ export const StoryGenerator: React.FC = () => {
               </div>
               <h1 className="text-lg sm:text-xl font-display font-bold">Storybook Generator</h1>
             </div>
-            
+
+            {user && (
+              <div className="flex items-center gap-3">
+                <div className="text-xs sm:text-sm text-muted-foreground text-right">
+                  <div className="font-medium text-foreground">{user.email}</div>
+                  <div>Signed in</div>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => signOut().catch((err) => console.error('Failed to sign out', err))}
+                  className="flex items-center gap-2"
+                >
+                  <LogOut className="w-4 h-4" />
+                  Sign out
+                </Button>
+              </div>
+            )}
+
             {/* Step indicator */}
             <div className="flex flex-wrap items-center gap-1 sm:gap-2 w-full sm:w-auto">
               {['Setup', 'Preview', 'Edit', 'Export'].map((step, index) => {
@@ -144,6 +167,7 @@ export const StoryGenerator: React.FC = () => {
           <ExportPanel
             config={config}
             onConfigChange={updateConfig}
+            onReset={resetState}
             onBack={handleBack}
           />
         )}

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,129 @@
+import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { User } from '@supabase/supabase-js';
+import { supabase } from '@/integrations/supabase/client';
+
+type AuthMode = 'sign-in' | 'sign-up';
+
+interface AuthContextValue {
+  user: User | null;
+  loading: boolean;
+  mode: AuthMode;
+  error: string | null;
+  setMode: (mode: AuthMode) => void;
+  clearError: () => void;
+  signIn: (email: string, password: string) => Promise<void>;
+  signUp: (email: string, password: string) => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [mode, setMode] = useState<AuthMode>('sign-in');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const initialise = async () => {
+      try {
+        const { data } = await supabase.auth.getUser();
+        if (isMounted) {
+          setUser(data.user ?? null);
+        }
+      } catch (err) {
+        console.error('[AuthProvider] Failed to load user', err);
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    initialise();
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      isMounted = false;
+      listener.subscription.unsubscribe();
+    };
+  }, []);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const signIn = useCallback(async (email: string, password: string) => {
+    setError(null);
+    try {
+      const { error: signInError } = await supabase.auth.signInWithPassword({ email, password });
+      if (signInError) {
+        throw signInError;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to sign in';
+      setError(message);
+      throw err;
+    }
+  }, []);
+
+  const signUp = useCallback(async (email: string, password: string) => {
+    setError(null);
+    try {
+      const { error: signUpError } = await supabase.auth.signUp({
+        email,
+        password,
+        options: { emailRedirectTo: window?.location?.origin ?? undefined },
+      });
+      if (signUpError) {
+        throw signUpError;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to sign up';
+      setError(message);
+      throw err;
+    }
+  }, []);
+
+  const signOut = useCallback(async () => {
+    try {
+      const { error: signOutError } = await supabase.auth.signOut();
+      if (signOutError) {
+        throw signOutError;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to sign out';
+      setError(message);
+      throw err;
+    }
+  }, []);
+
+  const value = useMemo<AuthContextValue>(() => ({
+    user,
+    loading,
+    mode,
+    error,
+    setMode,
+    clearError,
+    signIn,
+    signUp,
+    signOut,
+  }), [user, loading, mode, error, setMode, clearError, signIn, signUp, signOut]);
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = (): AuthContextValue => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return ctx;
+};

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -5,13 +5,18 @@ export interface SessionData {
   sessionId: string;
   firstExportUsed: boolean;
   createdAt: number;
+  userId?: string;
 }
 
-const SESSION_KEY = 'storybook_session';
+const SESSION_KEY_PREFIX = 'storybook_session';
 
-export function getSession(): SessionData {
-  const stored = localStorage.getItem(SESSION_KEY);
-  
+const getStorageKey = (userId?: string) =>
+  userId ? `${SESSION_KEY_PREFIX}_${userId}` : SESSION_KEY_PREFIX;
+
+export function getSession(userId?: string): SessionData {
+  const storageKey = getStorageKey(userId);
+  const stored = localStorage.getItem(storageKey);
+
   if (stored) {
     try {
       return JSON.parse(stored);
@@ -19,28 +24,29 @@ export function getSession(): SessionData {
       // Invalid data, create new session
     }
   }
-  
+
   // Create new session
   const newSession: SessionData = {
     sessionId: generateSessionId(),
     firstExportUsed: false,
-    createdAt: Date.now()
+    createdAt: Date.now(),
+    userId,
   };
-  
-  localStorage.setItem(SESSION_KEY, JSON.stringify(newSession));
+
+  localStorage.setItem(storageKey, JSON.stringify(newSession));
   return newSession;
 }
 
-export function updateSession(updates: Partial<SessionData>): SessionData {
-  const session = getSession();
-  const updatedSession = { ...session, ...updates };
-  
-  localStorage.setItem(SESSION_KEY, JSON.stringify(updatedSession));
+export function updateSession(updates: Partial<SessionData>, userId?: string): SessionData {
+  const session = getSession(userId);
+  const updatedSession = { ...session, ...updates, userId: userId ?? session.userId };
+
+  localStorage.setItem(getStorageKey(userId ?? session.userId), JSON.stringify(updatedSession));
   return updatedSession;
 }
 
-export function markFirstExportUsed(): void {
-  updateSession({ firstExportUsed: true });
+export function markFirstExportUsed(userId?: string): void {
+  updateSession({ firstExportUsed: true }, userId);
 }
 
 function generateSessionId(): string {

--- a/src/state.ts
+++ b/src/state.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { AppState, StoryConfig, AppStep, ValidationError } from './types';
 
 // Initial state for the app
-const initialConfig: StoryConfig = {
+const createInitialConfig = (): StoryConfig => ({
   children: [],
   storyType: '',
   themePreset: null,
@@ -19,12 +19,12 @@ const initialConfig: StoryConfig = {
   imageStyle: 'Picture-book',
   pageSize: 'A5 portrait',
   imageSeed: null,
-};
+});
 
 export const useAppState = () => {
   const [state, setState] = useState<AppState>({
     currentStep: 'setup',
-    config: initialConfig,
+    config: createInitialConfig(),
     isGenerating: false,
     errors: [],
   });
@@ -55,6 +55,15 @@ export const useAppState = () => {
 
   const clearErrors = useCallback(() => {
     setState(prev => ({ ...prev, errors: [] }));
+  }, []);
+
+  const resetState = useCallback(() => {
+    setState({
+      currentStep: 'setup',
+      config: createInitialConfig(),
+      isGenerating: false,
+      errors: [],
+    });
   }, []);
 
   // Validation helpers
@@ -99,5 +108,6 @@ export const useAppState = () => {
     clearErrors,
     validateConfig,
     canProceedToNext,
+    resetState,
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,4 +136,5 @@ export interface PrintOrderResponse {
   orderId?: string;
   checkoutUrl?: string;
   raw?: any;
+  error?: string;
 }

--- a/supabase/functions/generate-images/index.ts
+++ b/supabase/functions/generate-images/index.ts
@@ -16,8 +16,11 @@ serve(async (req) => {
     
     const geminiKey = Deno.env.get('GEMINI_API_KEY')
     if (!geminiKey) {
-      throw new Error('GEMINI_API_KEY is required')
+      throw new Error('GEMINI_API_KEY is required. Please add it to your environment variables.')
     }
+
+    const geminiModel = Deno.env.get('GEMINI_IMAGE_MODEL') || 'gemini-nano-banana-storybooks';
+    const encodedModel = encodeURIComponent(geminiModel);
 
     // Calculate dimensions based on page size (300 DPI with 3mm bleed)
     const pageSizes = {
@@ -57,9 +60,9 @@ serve(async (req) => {
         
         let dataUrl: string | null = null
 
-        // Use Gemini 2.5 Flash for image generation
+        // Use fine-tuned Gemini Nano Banana model for image generation
         try {
-          console.log(`Generating image for page ${promptData.page} with Gemini 2.5 Flash`)
+          console.log(`Generating image for page ${promptData.page} with model ${geminiModel}`)
           
           const geminiPayload = {
             contents: [{
@@ -72,7 +75,7 @@ serve(async (req) => {
             }
           }
 
-          const geminiResponse = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${geminiKey}`, {
+          const geminiResponse = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${encodedModel}:generateContent?key=${geminiKey}`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/supabase/functions/story-write/index.ts
+++ b/supabase/functions/story-write/index.ts
@@ -18,7 +18,7 @@ serve(async (req) => {
 
     if (!openaiKey) {
       console.error('OpenAI API key not configured')
-      throw new Error('OpenAI API key not configured')
+      throw new Error('OpenAI API key not configured. Add OPENAI_API_KEY to your project environment.')
     }
 
     const pages = []
@@ -87,7 +87,7 @@ Important Instructions:
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          model: 'gpt-5-2025-08-07',
+          model: 'gpt-4.1',
           messages: [
             {
               role: 'system',
@@ -120,7 +120,7 @@ Important Instructions:
           method: 'POST',
           headers: { 'Authorization': `Bearer ${openaiKey}`, 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            model: 'gpt-5-2025-08-07',
+            model: 'gpt-4.1',
             messages: [
               { role: 'system', content: `You write professional children's book pages in UK English with the quality of published books. Return ONLY the story text and ensure word-count target is met exactly.` },
               { role: 'user', content: `${writingPrompt}\n\nWrite between ${config.readingLevel === 'Toddler 2–3' ? '60 and 80' : config.readingLevel === 'Early 4–5' ? '80 and 120' : '120 and 150'} words (aim ${pageOutline.wordCount || pageOutline.wordsTarget || 100}).` }
@@ -141,7 +141,7 @@ Important Instructions:
           method: 'POST',
           headers: { 'Authorization': `Bearer ${openaiKey}`, 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            model: 'gpt-5-2025-08-07',
+            model: 'gpt-4.1',
             messages: [
               { role: 'system', content: 'Write professional UK English children\'s story pages with published book quality. Return ONLY story text, no quotes or extra text.' },
               { role: 'user', content: `Write page ${pageOutline.page} of a ${config.lengthPages}-page children\'s story about ${config.children.join(' and ') || 'a child'} and their pet dog ${config.personal?.pets || 'Ivy'}. Setting: ${config.setting}. Reading level: ${config.readingLevel}. Style: ${config.narrationStyle}. Write exactly ${pageOutline.wordCount || 70} words. Include these personal details naturally: town ${config.personal?.town || ''}, favorite toy ${config.personal?.favouriteToy || ''}, favorite color ${config.personal?.favouriteColour || ''}. Return ONLY the story text.` }
@@ -183,7 +183,7 @@ Important Instructions:
           method: 'POST',
           headers: { 'Authorization': `Bearer ${openaiKey}`, 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            model: 'gpt-5-2025-08-07',
+            model: 'gpt-4.1',
             messages: [
               { role: 'system', content: `Revise children\'s story text to meet word-count and level exactly while maintaining professional quality and ${config.narrationStyle} style.` },
               { role: 'user', content: `Adjust the following text to be between ${min}-${max} words (aim ${target}). Keep UK English and all proper nouns. Return ONLY the revised text.\n\nText:\n"""${pageText}"""` }


### PR DESCRIPTION
## Summary
- add a Supabase-backed email/password auth gate around the story generator experience
- switch story planning/writing to GPT-4.1, call the Gemini nano banana fine-tuned model for art (including page-level regeneration), and surface clearer API key errors
- embed generated art into exported PDFs, improve print-order responses, and persist export entitlement state per user

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e22c218ddc833293b79a72349cce7a